### PR TITLE
cnidarium: prepare `v0.81.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cnidarium"
-version = "0.80.0"
+version = "0.81.0"
 authors = [
   "Penumbra Labs <team@penumbralabs.xyz>",
   "Henry de Valence <hdevalence@penumbralabs.xyz>",


### PR DESCRIPTION
This bumps the version to `v0.81.0` to cut a release including #3 