### PR TITLE
Prepare `v0.82.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cnidarium"
-version = "0.82.0"
+version = "0.82.1"
 authors = [
   "Penumbra Labs <team@penumbralabs.xyz>",
   "Henry de Valence <hdevalence@penumbralabs.xyz>",

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -1,0 +1,9 @@
+// Autogen code isn't clippy clean:
+#[allow(clippy::unwrap_used)]
+pub mod v1 {
+    include!("gen/penumbra.cnidarium.v1.rs");
+    include!("gen/penumbra.cnidarium.v1.serde.rs");
+}
+
+// https://github.com/penumbra-zone/penumbra/issues/3038#issuecomment-1722534133
+pub const FILE_DESCRIPTOR_SET: &[u8] = include_bytes!("gen/proto_descriptor.bin.no_lfs");


### PR DESCRIPTION
This is a point release to sneak in a `proto` module that was omitted in `v0.82.0`