### PR TITLE
Feature gate rocksdb, for lightweight consumption

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,19 @@ documentation = "https://docs.rs/cnidarium"
 [features]
 migration = []
 migration-proptests = ["migration"]
-default = ["metrics"]
+default = ["metrics", "full"]
+# Intended to be the full set of heavy features, with possible expansion.
+full = ["rocksdb"]
 rpc = ["proto"]
 proto = ["dep:tonic", "dep:prost", "dep:serde", "dep:pbjson", "dep:ibc-proto"]
+rocksdb = ["dep:rocksdb"]
 
 [dependencies]
 anyhow = "1.0.86"
 async-trait = "0.1.80"
 base64 = "0.21.7"
 borsh = { version = "1.3.0" , features = ["derive", "de_strict_order"]}
+cfg-if = "1.0"
 futures = "0.3.30"
 hex = "0.4.3"
 ibc-proto = { version = "0.51.1", default-features = false, features = ["serde"], optional = true }
@@ -38,7 +42,7 @@ pbjson = { version = "0.7", optional = true }
 pin-project = "1.1.5"
 prost = { version = "0.13.3", optional = true }
 regex = "1.10.5"
-rocksdb = "0.21"
+rocksdb = { version = "0.21", optional = true }
 serde = { version = "1", optional = true}
 sha2 = "0.10"
 smallvec = { version = "1.10", features = ["union", "const_generics"] }

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,4 @@
+check:
+	cargo check --release
+	cargo check --release --no-default-features
+	cargo check --release --no-default-features --features "proto"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,38 +57,44 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // We use `HashMap`s opportunistically.
 #![allow(clippy::disallowed_types)]
+use cfg_if::cfg_if;
 
-mod cache;
-mod delta;
-mod escaped_byte_slice;
-mod metrics;
 mod read;
-mod snapshot;
-mod snapshot_cache;
-mod storage;
-mod store;
-#[cfg(test)]
-mod tests;
-mod utils;
-mod write;
-mod write_batch;
-
-#[cfg(feature = "metrics")]
-pub use crate::metrics::register_metrics;
-pub use cache::Cache;
-pub use delta::{ArcStateDeltaExt, StateDelta};
-pub use escaped_byte_slice::EscapedByteSlice;
-pub use jmt::{ics23_spec, RootHash};
 pub use read::StateRead;
-pub use snapshot::Snapshot;
-pub use storage::{Storage, TempStorage};
+mod write;
 pub use write::StateWrite;
-pub use write_batch::StagedWriteBatch;
-
-pub mod future;
-
-#[cfg(feature = "rpc")]
-pub mod rpc;
-
 #[cfg(feature = "proto")]
 pub mod proto;
+
+cfg_if! {
+    if #[cfg(feature = "rocksdb")] {
+        mod cache;
+        mod delta;
+        mod escaped_byte_slice;
+        mod metrics;
+        mod snapshot;
+        mod snapshot_cache;
+        mod storage;
+        mod store;
+        #[cfg(test)]
+        mod tests;
+        mod utils;
+        mod write_batch;
+
+        #[cfg(feature = "metrics")]
+        pub use crate::metrics::register_metrics;
+        pub use cache::Cache;
+        pub use delta::{ArcStateDeltaExt, StateDelta};
+        pub use escaped_byte_slice::EscapedByteSlice;
+        pub use jmt::{ics23_spec, RootHash};
+        pub use snapshot::Snapshot;
+        pub use storage::{Storage, TempStorage};
+        pub use write_batch::StagedWriteBatch;
+
+        pub mod future;
+
+        #[cfg(feature = "rpc")]
+        pub mod rpc;
+
+    }
+}

--- a/tests/migration.rs
+++ b/tests/migration.rs
@@ -378,10 +378,7 @@ async fn test_substore_migration() -> anyhow::Result<()> {
 
     let old_version = storage.latest_version();
     assert_eq!(old_version, num_versions_pre_migration - 1); // -1 because we start at u64::MAX
-    let premigration_root_hash = premigration_snapshot
-        .root_hash()
-        .await
-        .expect("infallible");
+    let premigration_root_hash = premigration_snapshot.root_hash().await.expect("infallible");
     drop(premigration_snapshot);
 
     /* ******************************* */


### PR DESCRIPTION
Now it's possible to consume just the traits, which allows for much easier lightweight compilation.

You can also depend on the protos, that feature remains orthogonal.

I added a `just check` command to easily check the feature set here.